### PR TITLE
Implement Golf Course Insights Tool

### DIFF
--- a/backend/.env.template
+++ b/backend/.env.template
@@ -18,3 +18,6 @@ LANGCHAIN_PROJECT="your_project_name_here"
 # Development: Set to "development" to run API-only mode
 # Production: Set to "production" to serve static frontend content
 ENVIRONMENT=development 
+
+# Debug Mode - a simple way to print debug messages to the console. FUTURE: Use a logging module.
+DEBUG=false

--- a/backend/.env.template
+++ b/backend/.env.template
@@ -4,7 +4,15 @@
 ALLOWED_ORIGINS=*
 
 # Required API Keys
-OPENAI_API_KEY=your-openai-api-key-here
+OPENAI_API_KEY=your_openai_api_key_here
+TAVILY_API_KEY=your_tavily_api_key_here
+LANGCHAIN_API_KEY=your_langchain_api_key_here
+GOLFCOURSE_API_KEY=your_golfcourse_api_key_here
+
+#LangSmith Variables
+LANGCHAIN_TRACING_V2=true
+LANGCHAIN_ENDPOINT=https://api.smith.langchain.com
+LANGCHAIN_PROJECT="your_project_name_here"
 
 # Environment Setting
 # Development: Set to "development" to run API-only mode

--- a/backend/tests/test_course_insights_tool.py
+++ b/backend/tests/test_course_insights_tool.py
@@ -1,0 +1,231 @@
+import os
+import pytest
+import requests
+from unittest.mock import patch, MagicMock
+from backend.tools.course_insights_tool import course_insights
+
+@pytest.fixture(autouse=True)
+def fake_env():
+    """Mock environment variables for all tests."""
+    with patch.dict(os.environ, {"GOLFCOURSE_API_KEY": "fake-api-key"}):
+        yield
+
+@pytest.fixture
+def mock_search_response():
+    return {
+        "courses": [
+            {
+                "id": "12345",
+                "course_name": "Championship Course",
+                "club_name": "Pine Valley Golf Club"
+            }
+        ]
+    }
+
+@pytest.fixture
+def mock_detail_response():
+    return {
+        "location": {
+            "address": "123 Golf Lane, Pine Valley, NJ 08021"
+        },
+        "tees": {
+            "male": [
+                {
+                    "course_rating": 74.1,
+                    "slope_rating": 155,
+                    "total_yards": 7280,
+                    "par_total": 72
+                }
+            ]
+        }
+    }
+
+@pytest.fixture
+def mock_requests_get():
+    """Mock the requests.get method."""
+    with patch('requests.get') as mock:
+        yield mock
+
+# @pytest.fixture
+# def mock_requests():
+#     """Mock the requests module to avoid actual API calls."""
+#     with patch('backend.tools.course_insights_tool.requests') as mock:
+#         # Set up the get method to return a mock response
+#         mock_response = MagicMock()
+#         mock_response.json.return_value = {}
+#         mock_response.raise_for_status.return_value = None
+#         mock.get.return_value = mock_response
+#         yield mock
+
+def test_course_insights_successful(mock_search_response, mock_detail_response, mock_requests_get):
+    """Test successful course insights retrieval"""
+    # Set up the mock responses
+    search_response = MagicMock()
+    search_response.json.return_value = mock_search_response
+    search_response.raise_for_status.return_value = None
+    
+    detail_response = MagicMock()
+    detail_response.json.return_value = mock_detail_response
+    detail_response.raise_for_status.return_value = None
+    
+    # Configure the mock to return different responses for different URLs
+    mock_requests_get.side_effect = [search_response, detail_response]
+    
+    # Call the function
+    result = course_insights.invoke("Pine Valley")
+    
+    # Verify the result
+    expected_result = (
+        "Pine Valley Golf Club - Championship Course (ID: 12345)\n"
+        "Location: 123 Golf Lane, Pine Valley, NJ 08021\n"
+        "Rating: 74.1 | Slope: 155\n"
+        "Yards: 7280 | Par: 72\n"
+        "Hardest Hole: TBD\n"
+    )
+    assert result == expected_result
+    
+    # Verify the API calls
+    mock_requests_get.assert_any_call(
+        "https://api.golfcourseapi.com/v1/search", 
+        headers={"Authorization": "Key fake-api-key"}, 
+        params={"search_query": "Pine Valley"}
+    )
+    mock_requests_get.assert_any_call(
+        "https://api.golfcourseapi.com/v1/courses/12345", 
+        headers={"Authorization": "Key fake-api-key"}
+    )
+
+def test_course_insights_no_courses_found(mock_requests_get):
+    """Test when no courses are found for the search query"""
+    # Set up the mock response
+    search_response = MagicMock()
+    search_response.json.return_value = {"courses": []}
+    search_response.raise_for_status.return_value = None
+    
+    # Configure the mock
+    mock_requests_get.return_value = search_response
+    
+    # Call the function
+    result = course_insights.invoke("Nonexistent Golf Club")
+    
+    # Verify the result
+    assert result == "No courses found for query 'Nonexistent Golf Club'."
+
+def test_course_insights_no_tee_data(mock_search_response, mock_requests_get):
+    """Test when no tee data is available for the course"""
+    # Set up the mock responses
+    search_response = MagicMock()
+    search_response.json.return_value = mock_search_response
+    search_response.raise_for_status.return_value = None
+    
+    detail_response = MagicMock()
+    detail_response.json.return_value = {
+        "location": {"address": "123 Golf Lane"},
+        "tees": {"male": [], "female": []}
+    }
+    detail_response.raise_for_status.return_value = None
+    
+    # Configure the mock
+    mock_requests_get.side_effect = [search_response, detail_response]
+    
+    # Call the function
+    result = course_insights.invoke("Pine Valley")
+    
+    # Verify the result
+    assert result == "No tee data available for any course found for query 'Pine Valley'."
+
+def test_course_insights_female_tee_data(mock_search_response, mock_requests_get):
+    """Test when only female tee data is available"""
+    # Set up the mock responses
+    search_response = MagicMock()
+    search_response.json.return_value = mock_search_response
+    search_response.raise_for_status.return_value = None
+    
+    detail_response = MagicMock()
+    detail_response.json.return_value = {
+        "location": {"address": "123 Golf Lane, Pine Valley, NJ 08021"},
+        "tees": {
+            "male": [],
+            "female": [
+                {
+                    "course_rating": 72.5,
+                    "slope_rating": 140,
+                    "total_yards": 6500,
+                    "par_total": 72
+                }
+            ]
+        }
+    }
+    detail_response.raise_for_status.return_value = None
+    
+    # Configure the mock
+    mock_requests_get.side_effect = [search_response, detail_response]
+    
+    # Call the function
+    result = course_insights.invoke("Pine Valley")
+    
+    # Verify the result
+    expected_result = (
+        "Pine Valley Golf Club - Championship Course (ID: 12345)\n"
+        "Location: 123 Golf Lane, Pine Valley, NJ 08021\n"
+        "Rating: 72.5 | Slope: 140\n"
+        "Yards: 6500 | Par: 72\n"
+        "Hardest Hole: TBD\n"
+    )
+    assert result == expected_result
+
+def test_course_insights_http_error(mock_requests_get):
+    """Test handling of HTTP error"""
+    # Set up the mock to raise an exception with a 404 error message
+    mock_requests_get.side_effect = requests.HTTPError("404 Not Found")
+    
+    # Call the function
+    result = course_insights.invoke("Pine Valley")
+    
+    # Verify the result
+    assert result.startswith("API request failed")
+
+def test_course_insights_unexpected_error(mock_requests_get):
+    """Test handling of unexpected exception"""
+    # Set up the mock to raise an unexpected exception
+    mock_requests_get.side_effect = ValueError("Invalid JSON")
+    
+    # Call the function
+    result = course_insights.invoke("Pine Valley")
+    
+    # Verify the result
+    assert "Unexpected exception" in result
+
+@pytest.mark.parametrize("query", ["", "   ", "\n", "\t"])
+def test_course_insights_empty_query(query, mock_requests_get):
+    """Test handling of empty or whitespace-only queries"""
+    # Set up the mock response
+    search_response = MagicMock()
+    search_response.json.return_value = {"courses": []}
+    search_response.raise_for_status.return_value = None
+    
+    # Configure the mock
+    mock_requests_get.return_value = search_response
+    
+    # Call the function
+    result = course_insights.invoke(query)
+    
+    # Verify the result
+    assert result == f"No courses found for query '{query}'."
+
+def test_course_insights_missing_location(mock_search_response, mock_requests_get):
+    search_response = MagicMock()
+    search_response.json.return_value = mock_search_response
+    search_response.raise_for_status.return_value = None
+
+    detail_response = MagicMock()
+    detail_response.json.return_value = {
+        "tees": {"male": [{"course_rating": 74.1, "slope_rating": 155, "total_yards": 7280, "par_total": 72}]}
+        # Missing "location"
+    }
+    detail_response.raise_for_status.return_value = None
+
+    mock_requests_get.side_effect = [search_response, detail_response]
+    result = course_insights.invoke("Pine Valley")
+    assert "Pine Valley Golf Club - Championship Course" in result
+    assert "Address not available" in result

--- a/backend/tools/course_insights_tool.py
+++ b/backend/tools/course_insights_tool.py
@@ -1,50 +1,75 @@
 import os
+import json
 import requests
 from langchain.tools import tool
+from backend.tools.utils import debug_print
 
-GOLFCOURSE_API_KEY = os.environ["GOLFCOURSE_API_KEY"]
 BASE_URL = "https://api.golfcourseapi.com/v1"
 
-HEADERS = {
-    "Authorization": f"Key {GOLFCOURSE_API_KEY}"
-}
+def get_headers():
+    """Get the headers with the API key."""
+    api_key = os.environ.get("GOLFCOURSE_API_KEY", "fake-api-key")
+    return {
+        "Authorization": f"Key {api_key}"
+    }
 
 @tool
 def course_insights(search_query: str) -> str:
     """Fetches detailed course info for a given golf course name using GolfCourseAPI."""
+    
+    debug_print(f"[TOOL CALLED] course_insights: {search_query}")
+
+    if not search_query.strip():
+        return f"No courses found for query '{search_query}'."
+
     try:
         # Step 1: Search
-        search_resp = requests.get(f"{BASE_URL}/search", headers=HEADERS, params={"search_query": search_query})
+        search_resp = requests.get(f"{BASE_URL}/search", headers=get_headers(), params={"search_query": search_query})
         search_resp.raise_for_status()
         courses = search_resp.json().get("courses", [])
+        debug_print(f"[TOOL RESULT] course_insights: {json.dumps(search_resp.json())}")
 
         if not courses:
             return f"No courses found for query '{search_query}'."
+        else:
+            debug_print(f"Number of courses found: {len(courses)}")
 
-        course_id = courses[0]["id"]
-        course_name = courses[0]["course_name"]
-        club_name = courses[0]["club_name"]
+        for course_meta in courses:
+            course_id = course_meta["id"]
+            course_name = course_meta["course_name"]
+            club_name = course_meta["club_name"]
 
-        # Step 2: Fetch course by ID
-        detail_resp = requests.get(f"{BASE_URL}/courses/{course_id}", headers=HEADERS)
-        detail_resp.raise_for_status()
-        course = detail_resp.json()
+            detail_resp = requests.get(f"{BASE_URL}/courses/{course_id}", headers=get_headers())
+            detail_resp.raise_for_status()
+            data = detail_resp.json()
+            course = data.get("course", {})
 
-        male_tees = course.get("tees", {}).get("male", [])
-        if not male_tees:
-            return f"No male tee data available for {club_name} - {course_name}."
+            tees = course.get("tees", {})
+            all_tees = []
 
-        tee = male_tees[0]  # Assume the first tee (often the back tees)
+            if "male" in tees and tees["male"]:
+                all_tees.extend(tees["male"])
+            if "female" in tees and tees["female"]:
+                all_tees.extend(tees["female"])
 
-        return (
-            f"{club_name} - {course_name} (ID: {course_id})\n"
-            f"Location: {course['location']['address']}\n"
-            f"Rating: {tee['course_rating']} | Slope: {tee['slope_rating']}\n"
-            f"Yards: {tee['total_yards']} | Par: {tee['par_total']}\n"
-            f"Hardest Hole: TBD\n"
-        )
+            debug_print(f"Number of tees found: {len(all_tees)}")
+            
+            if all_tees:
+                tee = all_tees[0]  # Use the first tee available
+                return (
+                    f"{club_name} - {course_name} (ID: {course_id})\n"
+                    f"Location: {course.get('location', {}).get('address', 'Address not available')}\n"
+                    f"Rating: {tee.get('course_rating', 'N/A')} | Slope: {tee.get('slope_rating', 'N/A')}\n"
+                    f"Yards: {tee.get('total_yards', 'N/A')} | Par: {tee.get('par_total', 'N/A')}\n"
+                    f"Hardest Hole: TBD\n"
+                )
+
+        # fallback if none have tee data
+        return f"No tee data available for any course found for query '{search_query}'."
 
     except requests.HTTPError as e:
+        print(f"[ERROR] HTTPError: {e}")
         return f"API request failed: {e}"
     except Exception as e:
-        return f"Unexpected error: {e}"
+        print(f"[ERROR] Unexpected exception: {e}")
+        return f"Unexpected exception: {e}"

--- a/backend/tools/course_insights_tool.py
+++ b/backend/tools/course_insights_tool.py
@@ -1,0 +1,50 @@
+import os
+import requests
+from langchain.tools import tool
+
+GOLFCOURSE_API_KEY = os.environ["GOLFCOURSE_API_KEY"]
+BASE_URL = "https://api.golfcourseapi.com/v1"
+
+HEADERS = {
+    "Authorization": f"Key {GOLFCOURSE_API_KEY}"
+}
+
+@tool
+def course_insights(search_query: str) -> str:
+    """Fetches detailed course info for a given golf course name using GolfCourseAPI."""
+    try:
+        # Step 1: Search
+        search_resp = requests.get(f"{BASE_URL}/search", headers=HEADERS, params={"search_query": search_query})
+        search_resp.raise_for_status()
+        courses = search_resp.json().get("courses", [])
+
+        if not courses:
+            return f"No courses found for query '{search_query}'."
+
+        course_id = courses[0]["id"]
+        course_name = courses[0]["course_name"]
+        club_name = courses[0]["club_name"]
+
+        # Step 2: Fetch course by ID
+        detail_resp = requests.get(f"{BASE_URL}/courses/{course_id}", headers=HEADERS)
+        detail_resp.raise_for_status()
+        course = detail_resp.json()
+
+        male_tees = course.get("tees", {}).get("male", [])
+        if not male_tees:
+            return f"No male tee data available for {club_name} - {course_name}."
+
+        tee = male_tees[0]  # Assume the first tee (often the back tees)
+
+        return (
+            f"{club_name} - {course_name} (ID: {course_id})\n"
+            f"Location: {course['location']['address']}\n"
+            f"Rating: {tee['course_rating']} | Slope: {tee['slope_rating']}\n"
+            f"Yards: {tee['total_yards']} | Par: {tee['par_total']}\n"
+            f"Hardest Hole: TBD\n"
+        )
+
+    except requests.HTTPError as e:
+        return f"API request failed: {e}"
+    except Exception as e:
+        return f"Unexpected error: {e}"

--- a/backend/tools/registry.py
+++ b/backend/tools/registry.py
@@ -4,12 +4,17 @@ Tool registry for the agent. Add tools here to make them available to your agent
 
 from langchain.tools import Tool
 from backend.tools.search_golfpedia_tool import search_golfpedia
-
+from backend.tools.course_insights_tool import course_insights
 tools = [
     Tool(
         name="search_golfpedia",
         func=search_golfpedia,
         description="Searches the web for general golf-related knowledge using Tavily.",
+    ),
+    Tool(
+        name="course_insights",
+        func=course_insights,
+        description="Fetches detailed course info for a given golf course name using GolfCourseAPI.",
     ),
     # Add other tools here later
 ]

--- a/backend/tools/search_golfpedia_tool.py
+++ b/backend/tools/search_golfpedia_tool.py
@@ -1,7 +1,9 @@
 import os
+import json
 from tavily import TavilyClient
 from langchain.tools import tool
 from backend.tools.constants_tools import NO_SUMMARY_AVAILABLE
+from backend.tools.utils import debug_print
 
 # Initialize the client lazily to allow for environment variable mocking in tests
 def get_tavily_client():
@@ -10,6 +12,8 @@ def get_tavily_client():
 @tool
 def search_golfpedia(query: str) -> str:
     """Searches the web for general golf-related knowledge using Tavily."""
+    debug_print(f"[TOOL CALLED] search_golfpedia: {query}")
     tavily = get_tavily_client()
     result = tavily.search(query=query, search_depth="basic")
+    debug_print(f"[TOOL RESULT] search_golfpedia: {json.dumps(result, indent=2)}")
     return result["answer"] if "answer" in result else NO_SUMMARY_AVAILABLE

--- a/backend/tools/utils.py
+++ b/backend/tools/utils.py
@@ -1,0 +1,7 @@
+import os
+
+DEBUG = os.environ.get("DEBUG", "false").lower() == "true"
+
+def debug_print(msg):
+    if DEBUG:
+        print(msg)


### PR DESCRIPTION
Implementation of the `course_insights_tool` using the API from [api.golfcourseapi.com](https://api.golfcourseapi.com/). 

**NOTES:**
+ This also includes pytest unit tests for the tool.
+ This initial implementation simply finds the first course in the data returned that has any tee information in it. Much more work is left to do. Some examples:
  + Select the course based on proximity to a location found in the prompt (for example `City, State`)
  + Identify the hardest hole, list the holes in Stroke Index order, etc.