### PR TITLE
Implement Get Pro Stats Tool

### DIFF
--- a/backend/tests/test_get_pro_stats_tool.py
+++ b/backend/tests/test_get_pro_stats_tool.py
@@ -1,0 +1,88 @@
+import pytest
+from unittest.mock import patch
+from backend.tools.get_pro_stats_tool import get_pro_stats
+
+@pytest.fixture
+def mock_debug_print():
+    """Mock the debug_print function to avoid actual printing during tests."""
+    with patch('backend.tools.get_pro_stats_tool.debug_print') as mock:
+        yield mock
+
+def test_get_pro_stats_single_player_putting(mock_debug_print):
+    """Test getting putting stats for a single player."""
+    result = get_pro_stats.invoke("What is Scottie Scheffler's putting?")
+    
+    assert "SG Putting for Scottie Scheffler: Scottie Scheffler: 0.73" in result
+    mock_debug_print.assert_called_once()
+
+def test_get_pro_stats_single_player_driving(mock_debug_print):
+    """Test getting driving distance for a single player."""
+    result = get_pro_stats.invoke("What is Rory McIlroy's driving distance?")
+    
+    assert "Driving Distance for Rory McIlroy: Rory McIlroy: 326.3" in result
+    mock_debug_print.assert_called_once()
+
+def test_get_pro_stats_two_players_putting(mock_debug_print):
+    """Test comparing putting stats for two players."""
+    result = get_pro_stats.invoke("Compare putting between Scottie Scheffler and Rory McIlroy")
+    
+    assert "SG Putting comparison:" in result
+    assert "Scottie Scheffler: 0.73" in result
+    assert "Rory McIlroy: 0.19" in result
+    mock_debug_print.assert_called_once()
+
+def test_get_pro_stats_two_players_driving(mock_debug_print):
+    """Test comparing driving distance for two players."""
+    result = get_pro_stats.invoke("Compare driving between Bryson DeChambeau and Jon Rahm")
+    
+    assert "Driving Distance comparison:" in result
+    assert "Bryson DeChambeau: 337.8" in result
+    assert "Jon Rahm: 320.5" in result
+    mock_debug_print.assert_called_once()
+
+def test_get_pro_stats_three_players(mock_debug_print):
+    """Test comparing stats for three players."""
+    result = get_pro_stats.invoke("Compare putting between Scottie Scheffler, Rory McIlroy, and Jon Rahm")
+    
+    assert "SG Putting comparison:" in result
+    assert "Scottie Scheffler: 0.73" in result
+    assert "Rory McIlroy: 0.19" in result
+    assert "Jon Rahm: 0.45" in result
+    mock_debug_print.assert_called_once()
+
+def test_get_pro_stats_unknown_player(mock_debug_print):
+    """Test handling of unknown player."""
+    result = get_pro_stats.invoke("What is Tiger Woods' putting?")
+    
+    assert "Please specify at least one known player" in result
+    mock_debug_print.assert_called_once()
+
+def test_get_pro_stats_no_stat_keyword(mock_debug_print):
+    """Test handling of query without a stat keyword."""
+    result = get_pro_stats.invoke("Tell me about Scottie Scheffler")
+    
+    assert "Could not determine which stat to compare" in result
+    mock_debug_print.assert_called_once()
+
+def test_get_pro_stats_case_insensitive(mock_debug_print):
+    """Test that player names and stat keywords are case insensitive."""
+    result = get_pro_stats.invoke("Compare PUTTING between scottie scheffler and RORY MCILROY")
+    
+    assert "SG Putting comparison:" in result
+    assert "Scottie Scheffler: 0.73" in result
+    assert "Rory McIlroy: 0.19" in result
+    mock_debug_print.assert_called_once()
+
+def test_get_pro_stats_partial_name(mock_debug_print):
+    """Test that partial player names work."""
+    result = get_pro_stats.invoke("What is Bryson DeChambeau's driving?")
+    
+    assert "Driving Distance for Bryson DeChambeau: Bryson DeChambeau: 337.8" in result
+    mock_debug_print.assert_called_once()
+
+def test_get_pro_stats_empty_query(mock_debug_print):
+    """Test handling of empty query."""
+    result = get_pro_stats.invoke("")
+    
+    assert "Could not determine which stat to compare" in result
+    mock_debug_print.assert_called_once() 

--- a/backend/tools/get_pro_stats_tool.py
+++ b/backend/tools/get_pro_stats_tool.py
@@ -1,0 +1,41 @@
+from langchain.tools import tool
+from backend.tools.utils import debug_print
+
+MOCK_STATS_DB = {
+    "Scottie Scheffler": {"SG Putting": 0.73, "Driving Distance": 311.2},
+    "Rory McIlroy": {"SG Putting": 0.19, "Driving Distance": 326.3},
+    "Jon Rahm": {"SG Putting": 0.45, "Driving Distance": 320.5},
+    "Bryson DeChambeau": {"SG Putting": -0.12, "Driving Distance": 337.8}
+}
+
+@tool
+def get_pro_stats(query: str) -> str:
+    """Returns mock stat data for one or two PGA players from a simulated database."""
+    debug_print(f"[TOOL CALLED] get_pro_stats: {query}")
+
+    stat_keywords = ["putting", "distance", "accuracy", "driving"]
+    selected_stat = None
+    for keyword in stat_keywords:
+        if keyword in query.lower():
+            selected_stat = {
+                "putting": "SG Putting",
+                "distance": "Driving Distance",
+                "driving": "Driving Distance",
+                "accuracy": "Driving Accuracy"  # placeholder
+            }[keyword]
+            break
+
+    if not selected_stat:
+        return "Could not determine which stat to compare."
+
+    found_players = [name for name in MOCK_STATS_DB if name.lower() in query.lower()]
+
+    if not found_players:
+        return "Please specify at least one known player."
+
+    lines = [f"{name}: {MOCK_STATS_DB[name].get(selected_stat, 'N/A')}" for name in found_players]
+    
+    if len(found_players) == 1:
+        return f"{selected_stat} for {found_players[0]}: {lines[0]}"
+    else:
+        return f"{selected_stat} comparison:\n" + "\n".join(f"- {line}" for line in lines)

--- a/backend/tools/get_pro_stats_tool.py
+++ b/backend/tools/get_pro_stats_tool.py
@@ -28,7 +28,21 @@ def get_pro_stats(query: str) -> str:
     if not selected_stat:
         return "Could not determine which stat to compare."
 
-    found_players = [name for name in MOCK_STATS_DB if name.lower() in query.lower()]
+    # Find players in the query
+    found_players = []
+    for player in MOCK_STATS_DB:
+        if player.lower() in query.lower():
+            found_players.append(player)
+    
+    # If no exact matches, try partial matches
+    if not found_players:
+        for player in MOCK_STATS_DB:
+            # Split player name into parts and check if any part is in the query
+            name_parts = player.lower().split()
+            for part in name_parts:
+                if part in query.lower() and len(part) > 2:  # Only match parts longer than 2 chars
+                    found_players.append(player)
+                    break
 
     if not found_players:
         return "Please specify at least one known player."

--- a/backend/tools/registry.py
+++ b/backend/tools/registry.py
@@ -5,6 +5,8 @@ Tool registry for the agent. Add tools here to make them available to your agent
 from langchain.tools import Tool
 from backend.tools.search_golfpedia_tool import search_golfpedia
 from backend.tools.course_insights_tool import course_insights
+from backend.tools.get_pro_stats_tool import get_pro_stats
+
 tools = [
     Tool(
         name="search_golfpedia",
@@ -15,6 +17,11 @@ tools = [
         name="course_insights",
         func=course_insights,
         description="Fetches detailed course info for a given golf course name using GolfCourseAPI.",
+    ),
+    Tool(
+        name="get_pro_stats",
+        func=get_pro_stats,
+        description="Returns mock player stat comparisons from a simulated PGA database.",
     ),
     # Add other tools here later
 ]


### PR DESCRIPTION
Implementation of the get_pro_stats_tool using a mock dataset.

**NOTES:**
+ This also includes pytest unit tests for the tool.
+ Sample queries the mock data supports:
  + "Compare Scottie Scheffler and Rory McIlroy in putting"
  + "Which player has better driving distance: Bryson or Rahm?"
  + "Who is the better putter, Scottie or Rory?"

## Dataset
```
MOCK_STATS_DB = {
    "Scottie Scheffler": {"SG Putting": 0.73, "Driving Distance": 311.2},
    "Rory McIlroy": {"SG Putting": 0.19, "Driving Distance": 326.3},
    "Jon Rahm": {"SG Putting": 0.45, "Driving Distance": 320.5},
    "Bryson DeChambeau": {"SG Putting": -0.12, "Driving Distance": 337.8}
}
```